### PR TITLE
Fix setup section: separate setup from execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,41 +102,39 @@ npm install -g mini-todo-list-mcp
    
    See complete example: [/tasks/orchestrator-rules.md](https://github.com/ChrisColeTech/mini-todo-list-mcp/blob/main/tasks/orchestrator-rules.md)
 
-3. **You give the orchestrator this simple instruction**:
-   ```
-   "Use add-rules with filePath c:/path/to/orchestrator-rules.md and clearAll true, 
-   then use get-rules and follow the rules verbatim."
-   ```
-
-   The orchestrator loads its behavioral rules from the MCP server (which include the `bulk-add-todos` command), then coordinates work by getting task IDs and delegating actual implementation work to specialized CODE mode agents.
-
 ### Execution Flow
 
-**Step 1: Orchestrator loads rules and loads tasks**
+**Step 1: You give the orchestrator this simple instruction**:
+```
+"Use add-rules with filePath c:/path/to/orchestrator-rules.md and clearAll true, 
+then use get-rules and follow the rules verbatim."
+```
+
+**Step 2: Orchestrator loads rules and loads tasks**
 - Orchestrator calls `add-rules` with filePath: `c:/path/to/orchestrator-rules.md`, clearAll: true
 - Orchestrator calls `get-rules` to retrieve complete workflow instructions
 - Following Step 1 in rules: "FIRST THING YOU MUST DO: bulk-add-todos with folderPath /home/user/tasks and clearAll true"
 - Orchestrator calls `bulk-add-todos` with folderPath: `/home/user/tasks`, clearAll: true
 - MCP server responds: `✅ Created 10 todos`
 
-**Step 2: Orchestrator begins task assignment loop** 
+**Step 3: Orchestrator begins task assignment loop** 
 - Following Step 2 in rules: "Begin Task Assignment Loop"
 - Orchestrator calls `get-next-todo-id`
 - MCP server responds: `ID: 1, Task Number: 1`
 
-**Step 3: Orchestrator creates subtask using template**
+**Step 4: Orchestrator creates subtask using template**
 - Following Step 3 in rules: "Subtask Creation Template"
 - Orchestrator creates CODE mode subtask: "Call get-todo with id 1, read the complete task instructions and file content, then implement all required changes by creating files, writing code, or making modifications as specified in the task. When the implementation is complete, call complete-todo with id 1."
 - Subtask is assigned to CODE mode LLM
 
-**Step 4: CODE mode completes the work**
+**Step 5: CODE mode completes the work**
 - CODE mode calls `get-todo` with id: 1  
 - MCP server returns full todo item with embedded file content and detailed instructions
 - CODE mode executes the task by: creating new files, writing actual code, implementing features, refactoring existing code, adding tests, or whatever specific work the task requires
 - CODE mode calls `complete-todo` with id: 1
 - CODE mode returns "subtask complete" to orchestrator
 
-**Step 5: Loop repeats until done**
+**Step 6: Loop repeats until done**
 - Orchestrator follows workflow loop in rules: calls `get-next-todo-id` again
 - Process repeats until `get-next-todo-id` returns "All todos have been completed"
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,10 @@ npm install -g mini-todo-list-mcp
 2. **You create orchestrator rules file** that includes these key instructions:
    - Step 1: `bulk-add-todos with folderPath /home/user/tasks and clearAll true`
    - Step 2: Loop through `get-next-todo-id` and create CODE mode subtasks
-   - Step 3: Use specific subtask template for CODE mode agents
    
    See complete example: [/tasks/orchestrator-rules.md](https://github.com/ChrisColeTech/mini-todo-list-mcp/blob/main/tasks/orchestrator-rules.md)
 
-3. **You tell the orchestrator LLM**:
+3. **You give the orchestrator this simple instruction**:
    ```
    "Use add-rules with filePath c:/path/to/orchestrator-rules.md and clearAll true, 
    then use get-rules and follow the rules verbatim."

--- a/README.md
+++ b/README.md
@@ -112,33 +112,32 @@ npm install -g mini-todo-list-mcp
 
 ### Execution Flow
 
-**1. Orchestrator loads behavioral rules**
+**Step 1: Orchestrator loads rules and loads tasks**
 - Orchestrator calls `add-rules` with filePath: `c:/path/to/orchestrator-rules.md`, clearAll: true
-- Orchestrator calls `get-rules` to retrieve complete workflow instructions from MCP server
-
-**2. Orchestrator follows rules to load tasks**
-- Following Step 1 in the rules: "FIRST THING YOU MUST DO: bulk-add-todos with folderPath /home/user/tasks and clearAll true"
+- Orchestrator calls `get-rules` to retrieve complete workflow instructions
+- Following Step 1 in rules: "FIRST THING YOU MUST DO: bulk-add-todos with folderPath /home/user/tasks and clearAll true"
 - Orchestrator calls `bulk-add-todos` with folderPath: `/home/user/tasks`, clearAll: true
 - MCP server responds: `✅ Created 10 todos`
 
-**3. Orchestrator gets next task ID** 
-- Following the rules, orchestrator calls `get-next-todo-id`
+**Step 2: Orchestrator begins task assignment loop** 
+- Following Step 2 in rules: "Begin Task Assignment Loop"
+- Orchestrator calls `get-next-todo-id`
 - MCP server responds: `ID: 1, Task Number: 1`
 
-**4. Orchestrator creates subtask using rules template**
-- Using the message template from the rules, orchestrator creates subtask:
-- "Call get-todo with id 1, read the complete task instructions and file content, then implement all required changes by creating files, writing code, or making modifications as specified in the task. When the implementation is complete, call complete-todo with id 1."
+**Step 3: Orchestrator creates subtask using template**
+- Following Step 3 in rules: "Subtask Creation Template"
+- Orchestrator creates CODE mode subtask: "Call get-todo with id 1, read the complete task instructions and file content, then implement all required changes by creating files, writing code, or making modifications as specified in the task. When the implementation is complete, call complete-todo with id 1."
 - Subtask is assigned to CODE mode LLM
 
-**5. CODE mode completes the actual work**
+**Step 4: CODE mode completes the work**
 - CODE mode calls `get-todo` with id: 1  
 - MCP server returns full todo item with embedded file content and detailed instructions
 - CODE mode executes the task by: creating new files, writing actual code, implementing features, refactoring existing code, adding tests, or whatever specific work the task requires
 - CODE mode calls `complete-todo` with id: 1
 - CODE mode returns "subtask complete" to orchestrator
 
-**6. Process repeats until done**
-- Orchestrator calls `get-next-todo-id` again following the rules
+**Step 5: Loop repeats until done**
+- Orchestrator follows workflow loop in rules: calls `get-next-todo-id` again
 - Process repeats until `get-next-todo-id` returns "All todos have been completed"
 
 This orchestrator pattern works by having one LLM coordinate the overall project while specialized CODE agents handle the actual implementation. The orchestrator follows stored rules (via `get-rules`) to maintain consistent behavior and never sees file content—it only manages task IDs and creates subtasks. Each CODE agent gets complete context for one specific task and does the real work: writing code, creating files, implementing features, or refactoring components. This separation dramatically reduces token usage while ensuring perfect task isolation.

--- a/README.md
+++ b/README.md
@@ -104,39 +104,28 @@ npm install -g mini-todo-list-mcp
 
 ### Execution Flow
 
-**Step 1: You give the orchestrator this simple instruction**:
-```
-"Use add-rules with filePath c:/path/to/orchestrator-rules.md and clearAll true, 
-then use get-rules and follow the rules verbatim."
-```
+**Step 1: Load orchestrator rules**
+- You: "Use add-rules with filePath c:/path/to/orchestrator-rules.md and clearAll true, then use get-rules and follow the rules verbatim"
+- Orchestrator calls `add-rules` 
+- Orchestrator calls `get-rules`
 
-**Step 2: Orchestrator loads rules and loads tasks**
-- Orchestrator calls `add-rules` with filePath: `c:/path/to/orchestrator-rules.md`, clearAll: true
-- Orchestrator calls `get-rules` to retrieve complete workflow instructions
-- Following Step 1 in rules: "FIRST THING YOU MUST DO: bulk-add-todos with folderPath /home/user/tasks and clearAll true"
+**Step 2: Load task files**  
 - Orchestrator calls `bulk-add-todos` with folderPath: `/home/user/tasks`, clearAll: true
 - MCP server responds: `✅ Created 10 todos`
 
-**Step 3: Orchestrator begins task assignment loop** 
-- Following Step 2 in rules: "Begin Task Assignment Loop"
+**Step 3: Get next task and delegate**
 - Orchestrator calls `get-next-todo-id`
 - MCP server responds: `ID: 1, Task Number: 1`
+- Orchestrator creates CODE mode subtask: "Call get-todo with id 1, implement the task, call complete-todo with id 1"
 
-**Step 4: Orchestrator creates subtask using template**
-- Following Step 3 in rules: "Subtask Creation Template"
-- Orchestrator creates CODE mode subtask: "Call get-todo with id 1, read the complete task instructions and file content, then implement all required changes by creating files, writing code, or making modifications as specified in the task. When the implementation is complete, call complete-todo with id 1."
-- Subtask is assigned to CODE mode LLM
-
-**Step 5: CODE mode completes the work**
-- CODE mode calls `get-todo` with id: 1  
-- MCP server returns full todo item with embedded file content and detailed instructions
-- CODE mode executes the task by: creating new files, writing actual code, implementing features, refactoring existing code, adding tests, or whatever specific work the task requires
+**Step 4: CODE mode executes task**
+- CODE mode calls `get-todo` with id: 1
+- CODE mode implements the required changes
 - CODE mode calls `complete-todo` with id: 1
-- CODE mode returns "subtask complete" to orchestrator
 
-**Step 6: Loop repeats until done**
-- Orchestrator follows workflow loop in rules: calls `get-next-todo-id` again
-- Process repeats until `get-next-todo-id` returns "All todos have been completed"
+**Step 5: Repeat until done**
+- Orchestrator calls `get-next-todo-id` again
+- Process repeats until no more todos remain
 
 This orchestrator pattern works by having one LLM coordinate the overall project while specialized CODE agents handle the actual implementation. The orchestrator follows stored rules (via `get-rules`) to maintain consistent behavior and never sees file content—it only manages task IDs and creates subtasks. Each CODE agent gets complete context for one specific task and does the real work: writing code, creating files, implementing features, or refactoring components. This separation dramatically reduces token usage while ensuring perfect task isolation.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm install -g mini-todo-list-mcp
 ### 📋 Rules Management
 | Tool | Parameters | Purpose |
 |------|------------|--------|
-| `add-rules` | `filePath` (required): Path to rules file<br>`clearAll` (optional): Clear existing rules first | Reads entire file content and stores as single rule |
+| `add-rules` | `filePath` (required): Path to rules file<br>`clearAll` (optional): Clear existing rules first | Reads entire file content and stores as single rule. Adds to existing rules unless clearAll=true |
 | `get-rules` | `id` (optional): Specific rule ID | Returns all rules combined (no ID) or single rule (with ID) |
 
 ## 🎯 Real Orchestrator + Agent Workflow (Roo Code/Cline)

--- a/README.md
+++ b/README.md
@@ -61,27 +61,27 @@ npm install -g mini-todo-list-mcp
 ### 📝 Task Creation
 | Tool | Parameters | Purpose |
 |------|------------|--------|
-| `create-todo` | `title` (required): Task name<br>`description` (required): Task details<br>`filePath` (optional): File to embed | Create single task |
-| `bulk-add-todos` | `folderPath` (required): Directory to scan<br>`clearAll` (optional): Clear existing todos first | Create tasks from folder |
+| `create-todo` | `title` (required): Task name<br>`description` (required): Task details<br>`filePath` (optional): File to embed | Creates single todo with auto-assigned task number. If filePath provided, embeds entire file content in description |
+| `bulk-add-todos` | `folderPath` (required): Directory to scan<br>`clearAll` (optional): Clear existing todos first | Recursively scans folder, creates one todo per file with embedded content. Adds to existing todos unless clearAll=true |
 
 ### 🔍 Task Retrieval  
 | Tool | Parameters | Purpose |
 |------|------------|--------|
-| `get-next-todo` | No parameters | Get next task to work on |
-| `get-todo` | `id` (required): Todo ID number | Get specific task details |
-| `get-next-todo-id` | No parameters | Get next task ID only |
+| `get-next-todo` | No parameters | Returns next incomplete todo with full content (lowest task number, status != 'Done') |
+| `get-todo` | `id` (required): Todo ID number | Returns specific todo with full content including embedded file content |
+| `get-next-todo-id` | No parameters | Returns only ID and task number of next incomplete todo (no content) |
 
 ### ✏️ Task Management
 | Tool | Parameters | Purpose |
 |------|------------|--------|
-| `update-todo` | `id` (required): Todo ID number<br>`title` (optional): New task name<br>`description` (optional): New task details | Modify existing task |
-| `complete-todo` | `id` (required): Todo ID number | Mark task as done |
-| `delete-todo` | `id` (required): Todo ID number | Remove task permanently |
+| `update-todo` | `id` (required): Todo ID number<br>`title` (optional): New task name<br>`description` (optional): New task details | Updates existing todo. At least one field (title or description) required |
+| `complete-todo` | `id` (required): Todo ID number | Marks todo as completed (status='Done', sets completedAt timestamp) |
+| `delete-todo` | `id` (required): Todo ID number | Permanently removes todo from database |
 
 ### 🗂️ Bulk Operations
 | Tool | Parameters | Purpose |
 |------|------------|--------|
-| `clear-all-todos` | No parameters | Start fresh |
+| `clear-all-todos` | No parameters | Deletes all todos from database (returns count of deleted items) |
 
 ### 📋 Rules Management
 | Tool | Parameters | Purpose |

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ npm install -g mini-todo-list-mcp
 ### 📋 Rules Management
 | Tool | Parameters | Purpose |
 |------|------------|--------|
-| `add-rules` | `filePath` (required): Path to rules file<br>`clearAll` (optional): Clear existing rules first | Load orchestrator rules from file |
-| `get-rules` | `id` (optional): Specific rule ID | Retrieve orchestrator instructions |
+| `add-rules` | `filePath` (required): Path to rules file<br>`clearAll` (optional): Clear existing rules first | Reads entire file content and stores as single rule |
+| `get-rules` | `id` (optional): Specific rule ID | Returns all rules combined (no ID) or single rule (with ID) |
 
 ## 🎯 Real Orchestrator + Agent Workflow (Roo Code/Cline)
 

--- a/tasks/orchestrator-rules.md
+++ b/tasks/orchestrator-rules.md
@@ -1,45 +1,21 @@
 # Orchestrator Rules
 
-## IMPORTANT: Follow These Steps In Order
-
-### Step 1: Load All Task Files Into Todo System
-**FIRST THING YOU MUST DO:**
+## Step 1: Load Task Files
 ```
 bulk-add-todos with folderPath /home/user/tasks and clearAll true
 ```
-This command reads all task files from the folder and converts them into todo items with embedded file content. Wait for confirmation like "✅ Created 10 todos" before proceeding.
 
-### Step 2: Begin Task Assignment Loop
-**AFTER task files are loaded:**
-Repeatedly call get-next-todo-id and create CODE mode subtasks until no more todos remain.
-
-### Step 3: Subtask Creation Template
-For each task ID you receive, create a CODE mode subtask with this exact message template:
+## Step 2: Task Assignment Loop
+1. Call get-next-todo-id
+2. If you get a task ID, create CODE mode subtask using this template:
 
 ```
 Call get-todo with id [TASK_ID], read the complete task instructions and file content, then implement all required changes by creating files, writing code, or making modifications as specified in the task. When the implementation is complete, call complete-todo with id [TASK_ID].
 ```
 
-Replace [TASK_ID] with the actual ID number from get-next-todo-id.
-
-## Your Role as Orchestrator
-
-- **DO NOT** implement code yourself - only coordinate and delegate
-- **DO NOT** read file contents directly - let CODE mode agents handle that
-- **DO** focus on task IDs and creating subtasks for CODE mode agents
-- **DO** track progress by calling get-next-todo-id repeatedly
-- **DO** ensure each CODE mode agent gets exactly one task to complete
-
-## Workflow Loop
-
-1. Call get-next-todo-id
-2. If you get a task ID, create CODE mode subtask using the template above
 3. Wait for CODE mode to complete and report back
-4. Repeat from step 1 until get-next-todo-id returns "All todos have been completed"
+4. Repeat until get-next-todo-id returns "All todos have been completed"
 
-## Success Criteria
-
-- All task files converted to todos via bulk-add-todos
-- Each todo assigned to exactly one CODE mode agent
-- All todos marked as completed via complete-todo calls
-- Zero direct file operations by orchestrator (only coordination)
+## Your Role
+- Coordinate only - do not implement code yourself
+- Focus on task IDs and creating subtasks for CODE mode agents


### PR DESCRIPTION
## Summary
- Remove 'Subtask template for CODE mode agents' from setup section
- Setup should only show what the USER prepares, not what the orchestrator does during execution
- The subtask template is part of execution step 1, not setup preparation

## Changes
- Setup now clearly shows only preparation steps (task files, orchestrator rules, instruction)
- Execution details moved out of setup where they belong

🤖 Generated with [Claude Code](https://claude.ai/code)